### PR TITLE
enable-new-opts

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -26,8 +26,9 @@ export const generateStyles = (rules) => {
 export const generateStyledComponents = (styles) => {
   let components = []
   for (let i = 0; i < styles.length; i++) {
-    const style = styles[i]
-    let component = `const ${style.selector}Component = styled.${style.selector}\`
+    let style = styles[i]
+    let selector = removePrefixInSelector(getLastSelector(style.selector))
+    let component = `const ${selector}Component = styled.${selector}\`
     ${style.declarations.map(declaration => {
       return `\t${declaration.prop}: ${declaration.value};`
     }).join('\n')}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-function getDeclarations(ruleStyle) {
+export const getDeclarations = (ruleStyle) => {
   let declarations = []
   let foundDeclaration = true
   let ruleCount = 0; // first rule's prop starts at 0
@@ -15,7 +15,7 @@ function getDeclarations(ruleStyle) {
   return declarations;
 }
 
-function generateStyles(rules) {
+export const generateStyles = (rules) => {
   // returns an map of selectors to their respective declarations
   return rules.map((rule) => ({
     selector: rule.selectorText,
@@ -23,7 +23,7 @@ function generateStyles(rules) {
   }))
 }
 
-function generateStyledComponents(styles) {
+export const generateStyledComponents = (styles) => {
   let components = []
   for (let i = 0; i < styles.length; i++) {
     const style = styles[i]
@@ -38,7 +38,7 @@ function generateStyledComponents(styles) {
   return components;
 }
 
-function displayInfo(msg, level = 'error') {
+export const displayInfo = (msg, level = 'error') => {
   let info = ''
   if (level == 'error') {
     info = chalk.red.bold(`Operation Failed: ${msg}`)
@@ -48,9 +48,13 @@ function displayInfo(msg, level = 'error') {
   return info
 }
 
-export {
-  getDeclarations,
-  generateStyles,
-  generateStyledComponents,
-  displayInfo
+export const getLastSelector = (selectors) => {
+  let combinatorsRegExp = /[+|~|>| ]+/
+  let selectorList = selectors.split(combinatorsRegExp)
+  return selectorList[selectorList.length - 1]
+}
+
+export const removePrefixInSelector = (selector) => {
+  const classIDPrefixRegExp = /[.|#]/
+  return selector.replace(classIDPrefixRegExp, '')
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -85,4 +85,36 @@ describe('Utils', () => {
       expect(info).toEqual('success')
     })
   })
+
+  describe('getLastSelector', () => {
+    test('should get last selector from a string of selectors', () => {
+      let lastSelector = Utils.getLastSelector('a > b > c')
+      expect(lastSelector).toEqual('c')
+    })
+
+    test('should get last selector from a string of selectors', () => {
+      let lastSelector = Utils.getLastSelector('a + b ~ c')
+      expect(lastSelector).toEqual('c')
+    })
+
+    test('should get last selector from a string of selectors', () => {
+      let lastSelector = Utils.getLastSelector('a  b  c')
+      expect(lastSelector).toEqual('c')
+    })
+  })
+
+  describe('removePrefixInSelector', () => {
+    test('should remove class prefix in selector', () => {
+      let selector = Utils.removePrefixInSelector('.selector')
+      expect(selector).toEqual('selector')
+    })
+    test('should remove id prefix in selector', () => {
+      let selector = Utils.removePrefixInSelector('#selector')
+      expect(selector).toEqual('selector')
+    })
+    test('should return the selector without a prefix', () => {
+      let selector = Utils.removePrefixInSelector('selector')
+      expect(selector).toEqual('selector')
+    })
+  })
 })


### PR DESCRIPTION
**Changes Made**
- Remove class or id prefixes from selector names (improves the appearance of the generated component)
- Use the last selector name (using combinators as delimiters)